### PR TITLE
feat: show gateway url for IPFS pinning service

### DIFF
--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -92,7 +92,7 @@ async function main() {
 
   const deployOptions = {
     publicDirPath: argv.path,
-    copyPublicGatewayUrlToClipboard: !argv.noClipboard,
+    copyHttpGatewayUrlToClipboard: !argv.noClipboard,
     open: !argv.O,
     port: argv.port,
     remotePinners: argv.p,


### PR DESCRIPTION
To reduce the waiting time for the first view of the pinned site
use the pinning service http gateway url.

Changes references to "public gateway" to "http gateway" to be
consistent with how it works with this change in place.

fixes #4 