### PR TITLE
docs(README): Fix the npm scripts deploy example with the right command

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ IPFS_DEPLOY_CLOUDFLARE__RECORD=_dnslink.mysubdomain.agentofuser.com
 Important:
 
 - Note the 2 `_` after `PINATA` and `CLOUDFLARE`.
-- Remember you have to set the CNAME to cloudflare-ipfs.com yourself (only
+- Remember you have to set the CNAME to `cloudflare-ipfs.com` yourself (only
   once). ipfs-deploy then creates/updates the \_dnslink record.
 
 **Don't** commit the `.env` file to source control unless you know what you're
@@ -185,7 +185,7 @@ You can optionally add a deploy command to your `package.json`:
 //  ⋮
   "scripts": {
 //  ⋮
-    "deploy": "npx @agentofuser/ipfs-daemon public",
+    "deploy": "npx @agentofuser/ipfs-deploy public",
 //  ⋮
   }
 //  ⋮


### PR DESCRIPTION
The npm scripts example for deploy in the readme referenced `ipfs-daemon` instead of `ipfs-deploy`. Also a small tweak to make copying the CNAME target easier.